### PR TITLE
Enable changing style of entire rows

### DIFF
--- a/sum-it/Source/main/Cell/Container.cpp
+++ b/sum-it/Source/main/Cell/Container.cpp
@@ -77,7 +77,8 @@ void WarnForUnlockedContainer(int lineNr)
 const long kIndexSlotCount = 256;
 
 CContainer::CContainer(CCellView *inPane, CNameTable *inNames)
-	: fColumnStyles(kColCount, -1)
+	: fColumnStyles(kColCount, -1),
+	fRowStyles(kRowCount, -1)
 {
 	fInView = inPane;
 	fNames = inNames;
@@ -678,10 +679,13 @@ int CContainer::CollectFormats(int *formatList)
 			formatList[result++] = formatNr;
 	}
 
-	for (int i = 1; i < kColCount; i++)
+	for (int i = 1; i < kColCount + kRowCount; i++)
 	{
 		CellStyle cs;
-		GetColumnStyle(i, cs);
+		if (i < kColCount)
+			GetColumnStyle(i, cs);
+		else
+			GetRowStyle(i - kColCount + 1, cs);
 		int formatNr = cs.fFormat;
 		bool isNew = true;
 		

--- a/sum-it/Source/main/Cell/Container.h
+++ b/sum-it/Source/main/Cell/Container.h
@@ -138,6 +138,11 @@ public:
 	void SetColumnStyle(int, CellStyle&);
 	int GetColumnStyleNr(int);
 	void SetColumnStyleNr(int, int);
+
+	void GetRowStyle(int, CellStyle&);
+	void SetRowStyle(int, CellStyle&);
+	int GetRowStyleNr(int);
+	void SetRowStyleNr(int, int);
 	
 	void GetDefaultCellStyle(CellStyle&);
 	void SetDefaultCellStyle(CellStyle&);
@@ -159,6 +164,7 @@ public:
 /* accessors */
 	CCellView* GetOwner() const			{ return fInView; };
 	CRunArray2& GetColumnStyles()		{ return fColumnStyles; }
+	CRunArray2& GetRowStyles()			{ return fRowStyles; }
 	cell CalculatingCell() const		{ return fCalculatingCell; }
 	CNameTable *GetNameTable() const	{ return fNames; }
 	
@@ -183,6 +189,7 @@ private:
 	bool fNewNames;
 	int fDefaultCellStyle;
 	CRunArray2 fColumnStyles;
+	CRunArray2 fRowStyles;
 	cell fCalculatingCell;
 };
 

--- a/sum-it/Source/main/Cell/Container.styles.cpp
+++ b/sum-it/Source/main/Cell/Container.styles.cpp
@@ -80,8 +80,10 @@ int CContainer::GetCellStyleNr(const cell& inLoc)
 	
 	if ((i = fCellData.find(inLoc)) != fCellData.end())
 		return (*i).second.mStyle;
-	else
+	else if (GetColumnStyleNr(inLoc.h) != fDefaultCellStyle)
 		return GetColumnStyleNr(inLoc.h);
+	else
+		return GetRowStyleNr(inLoc.v);
 } /* GetCellStyleNr */
 
 void CContainer::SetCellStyleNr(const cell& inLoc, int inStyle)
@@ -126,6 +128,29 @@ void CContainer::SetColumnStyleNr(int colNr, int inStyle)
 	fColumnStyles.SetValue(colNr, inStyle);
 } /* SetColumnStyleNr */
 
+void CContainer::GetRowStyle(int rowNr, CellStyle& outStyle)
+{
+	outStyle = gStyleTable[GetRowStyleNr(rowNr)];
+} /* GetRowStyle */
+
+void CContainer::SetRowStyle(int rowNr, CellStyle& inStyle)
+{	CHECKLOCK
+	SetRowStyleNr(rowNr, gStyleTable.GetStyleID(inStyle));
+} /* SetRowStyle */
+
+int CContainer::GetRowStyleNr(int rowNr)
+{
+	if (fRowStyles[rowNr] >= 0)
+		return fRowStyles[rowNr];
+	else
+		return fDefaultCellStyle;
+} /* GetColumnStyleNr */
+
+void CContainer::SetRowStyleNr(int rowNr, int inStyle)
+{	CHECKLOCK
+	fRowStyles.SetValue(rowNr, inStyle);
+} /* SetColumnStyleNr */
+
 void CContainer::GetDefaultCellStyle(CellStyle& outStyle)
 {
 	outStyle = gStyleTable[fDefaultCellStyle];
@@ -157,9 +182,14 @@ int CContainer::CollectStyles(int *styleList)
 			styleList[result++] = styleNr;
 	}
 	
-	for (int i = 1; i < kColCount; i++)
+	// Go throught both column and row styles
+	for (int i = 1; i < kColCount + kRowCount; i++)
 	{
-		int styleNr = fColumnStyles[i];
+		int styleNr;
+		if (i < kColCount)
+			styleNr = fColumnStyles[i];
+		else
+			styleNr = fRowStyles[i - kColCount + 1];
 		bool isNew = true;
 
 		if (styleNr < 0) continue;

--- a/sum-it/Source/main/Commands/StyleCommand.cpp
+++ b/sum-it/Source/main/Commands/StyleCommand.cpp
@@ -57,6 +57,7 @@ CStyleCommand::CStyleCommand(CCellView *inView, CContainer *inContainer)
 	: CCellCommand(kStyleStrID, inView, inContainer)
 	, fSavedHeights(inView->GetHeights())
 	, fSavedColumnStyles(inContainer->GetColumnStyles())
+	, fSavedRowStyles(inContainer->GetRowStyles())
 {
 	StLocker<CContainer> lock(inContainer);
 
@@ -138,6 +139,13 @@ void CStyleCommand::DoCommand()
 			ChangeStyle(cs, height);
 			fSourceContainer->SetColumnStyle(i, cs);
 		}
+	if (fRowSelected)
+		for (int i = fAffected.top; i <= fAffected.bottom; i++)
+		{
+			fSourceContainer->GetRowStyle(i, cs);
+			ChangeStyle(cs, height);
+			fSourceContainer->SetRowStyle(i, cs);
+		}
 
 	UpdateView(true, false);
 } /* CStyleCommand::DoCommand */
@@ -194,6 +202,14 @@ void CStyleCommand::UndoCommand()
 		CRunArray2 tmp = fSourceContainer->GetColumnStyles();
 		fSourceContainer->GetColumnStyles() = fSavedColumnStyles;
 		fSavedColumnStyles = tmp;
+	}
+
+	if (fRowSelected)
+	{
+		StLocker<CContainer> lock(fSourceContainer);
+		CRunArray2 tmp = fSourceContainer->GetRowStyles();
+		fSourceContainer->GetRowStyles() = fSavedRowStyles;
+		fSavedRowStyles = tmp;
 	}
 
 	UpdateView(true, false);

--- a/sum-it/Source/main/Commands/StyleCommand.h
+++ b/sum-it/Source/main/Commands/StyleCommand.h
@@ -54,6 +54,7 @@ protected:
 	bool		fRowSelected, fColSelected;
 	CRunArray	fSavedHeights;
 	CRunArray2	fSavedColumnStyles;
+	CRunArray2	fSavedRowStyles;
 };
 
 class CFontStyleCommand : public CStyleCommand {

--- a/sum-it/Source/main/FileSys/FileFormat.h
+++ b/sum-it/Source/main/FileSys/FileFormat.h
@@ -96,6 +96,7 @@ enum scChunkType {
 	kscFormat = 'FM',		// Numberformat
 	kscStyle = 'ST',		// Format
 	kscColStyles = 'CS',	// Formats for columns
+	kscRowStyles = 'RS',	// Formats for rows
 	kscCellEmpty = 'CE',
 	kscCellBool = 'CB',
 	kscCellNumber = 'CN',


### PR DESCRIPTION
Previously, when a row was selected, changing its style only affected cells
which had some content. This was inconsistent with the way columns worked.

Fix for #16
